### PR TITLE
Correct the uses of older functions

### DIFF
--- a/tests/testthat/test-ds.asFactor.o.R
+++ b/tests/testthat/test-ds.asFactor.o.R
@@ -26,7 +26,7 @@ source("setup.R")
 
 context("dsBetaTestClient::ds.asFactor.o()")
 
-ds.asNumeric("D$time.id","TID")
+ds.asNumeric.o("D$time.id","TID")
 
 context("dsBetaTestClient::ds.asFactor.o(force.factor.levels)")
 

--- a/tests/testthat/test-ds.mean.o.R
+++ b/tests/testthat/test-ds.mean.o.R
@@ -54,7 +54,7 @@ test_that("mean values [split]", {
 
 context("dsBetaTestClient::ds.mean.o() test errors")
 test_that("mean_erros", {
-    ds.asCharacter(x='D$LAB_TSC', newobj="not_a_numeric")
+    ds.asCharacter.o(x='D$LAB_TSC', newobj="not_a_numeric")
 
     expect_error(ds.mean.o(), "Please provide the name of the input vector!", fixed=TRUE)
 #    expect_error(ds.mean.o(x='D$LAB_TSC', type='datashield'), 'Function argument "type" has to be either "combine" or "split"', fixed=TRUE)


### PR DESCRIPTION
Replaced: ds.asCharacter to ds.asCharacter.o
Replaced: ds.asNumeric to ds.asNumeric.o