### PR TITLE
Added support for 'notify.of.progress' to control console output

### DIFF
--- a/R/ds.cbind.o.R
+++ b/R/ds.cbind.o.R
@@ -54,6 +54,8 @@
 #' the argument can be specified as: e.g. datasources=opals.em[2].
 #' If you wish to specify the first and third opal servers in a set you specify:
 #' e.g. datasources=opals.em[c(1,3)]
+#' @param notify.of.progress specifies if console output should be produce to indicate
+#' progress. The default value for notify.of.progress is FALSE.
 #' @return the object specified by the <newobj> argument (or default name <cbind.out>).
 #' which is written to the serverside. Just like the {cbind} function in
 #' native R, the output object is of class matrix unless one or more
@@ -75,7 +77,7 @@
 #' will return the message: "ALL OK: there are no studysideMessage(s) on this datasource".
 #' @author Paul Burton for DataSHIELD Development Team
 #' @export
-ds.cbind.o<-function(x=NULL,DataSHIELD.checks=FALSE,force.colnames=NULL,newobj='cbind.out',datasources=NULL){
+ds.cbind.o<-function(x=NULL,DataSHIELD.checks=FALSE,force.colnames=NULL,newobj='cbind.out',datasources=NULL,notify.of.progress=FALSE){
   
   # if no opal login details are provided look for 'opal' objects in the environment
   if(is.null(datasources)){
@@ -133,7 +135,8 @@ testclass.var<-x[j]
 calltext1<-paste0('class(', testclass.var, ')')
 next.class <- opal::datashield.aggregate(datasources, as.symbol(calltext1))
 class.vector<-c(class.vector,next.class[[1]])
-cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n\n")
+if (notify.of.progress)
+    cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n")
 }
 
 for(j in 1:length(x))
@@ -143,17 +146,20 @@ test.df<-x[j]
 if(class.vector[j]!="data.frame" && class.vector[j]!="matrix")
 	{
 	colname.vector<-c(colname.vector,test.df)
-	cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n\n")
+        if (notify.of.progress)
+            cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
 	}
 else
 	{
 	calltext2<-paste0('colnames(', test.df, ')')
     df.names <- opal::datashield.aggregate(datasources, as.symbol(calltext2))
 	 colname.vector<-c(colname.vector,df.names[[1]])
-	 cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n\n")
+         if (notify.of.progress)
+             cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
 	}
 }
-cat("\n\nBoth steps completed\n")
+if (notify.of.progress)
+    cat("\nBoth steps completed\n")
 
 #CHECK FOR DUPLICATE NAMES IN COLUMN NAME VECTOR AND ADD ".k" TO THE kth REPLICATE
 num.duplicates<-rep(0,length(colname.vector))

--- a/R/ds.dataFrame.o.R
+++ b/R/ds.dataFrame.o.R
@@ -54,6 +54,8 @@
 #' the argument can be specified as: e.g. datasources=opals.em[2].
 #' If you wish to specify the first and third opal servers in a set you specify:
 #' e.g. datasources=opals.em[c(1,3)]
+#' @param notify.of.progress specifies if console output should be produce to indicate
+#' progress. The default value for notify.of.progress is FALSE.
 #' @return the object specified by the <newobj> argument (or default name <df_new>).
 #' which is written to the serverside. In addition, two validity messages are returned
 #' indicating whether <newobj> has been created in each data source and if so whether
@@ -69,7 +71,7 @@
 #' will return the message: "ALL OK: there are no studysideMessage(s) on this datasource".
 #' @author DataSHIELD Development Team
 #' @export
-ds.dataFrame.o<-function(x=NULL,row.names=NULL,check.rows=FALSE,check.names=TRUE,stringsAsFactors=TRUE,completeCases=FALSE,DataSHIELD.checks=FALSE,newobj='df_new',datasources=NULL){
+ds.dataFrame.o<-function(x=NULL,row.names=NULL,check.rows=FALSE,check.names=TRUE,stringsAsFactors=TRUE,completeCases=FALSE,DataSHIELD.checks=FALSE,newobj='df_new',datasources=NULL,notify.of.progress=FALSE){
   
   # if no opal login details are provided look for 'opal' objects in the environment
   if(is.null(datasources)){
@@ -123,7 +125,8 @@ testclass.var<-x[j]
 calltext1<-paste0('class(', testclass.var, ')')
 next.class <- opal::datashield.aggregate(datasources, as.symbol(calltext1))
 class.vector<-c(class.vector,next.class[[1]])
-cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n\n")
+if (notify.of.progress)
+    cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n")
 }
 
 for(j in 1:length(x))
@@ -133,17 +136,20 @@ test.df<-x[j]
 if(class.vector[j]!="data.frame" && class.vector[j]!="matrix")
 	{
 	colname.vector<-c(colname.vector,test.df)
-	cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n\n")
+        if (notify.of.progress)
+            cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
 	}
 else
 	{
 	calltext2<-paste0('colnames(', test.df, ')')
     df.names <- opal::datashield.aggregate(datasources, as.symbol(calltext2))
 	 colname.vector<-c(colname.vector,df.names[[1]])
-	 cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n\n")
-	}
+         if (notify.of.progress)
+             cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
+        }
 }
-cat("\n\nBoth steps completed\n")
+if (notify.of.progress)
+    cat("\nBoth steps completed\n")
 
 #CHECK FOR DUPLICATE NAMES IN COLUMN NAME VECTOR AND ADD ".k" TO THE kth REPLICATE
 num.duplicates<-rep(0,length(colname.vector))

--- a/R/ds.rbind.o.R
+++ b/R/ds.rbind.o.R
@@ -54,6 +54,8 @@
 #' the argument can be specified as: e.g. datasources=opals.em[2].
 #' If you wish to specify the first and third opal servers in a set you specify:
 #' e.g. datasources=opals.em[c(1,3)]
+#' @param notify.of.progress specifies if console output should be produce to indicate
+#' progress. The default value for notify.of.progress is FALSE.
 #' @return the object specified by the <newobj> argument (or default name <rbind.out>).
 #' which is written to the serverside. Unlike the {ds.cbind.o} function
 #' even if one of the objects specified in the <x> argument is a data.frame
@@ -73,7 +75,7 @@
 #' will return the message: "ALL OK: there are no studysideMessage(s) on this datasource".
 #' @author Paul Burton for DataSHIELD Development Team
 #' @export
-ds.rbind.o<-function(x=NULL,DataSHIELD.checks=FALSE,force.colnames=NULL,newobj='rbind.out',datasources=NULL){
+ds.rbind.o<-function(x=NULL,DataSHIELD.checks=FALSE,force.colnames=NULL,newobj='rbind.out',datasources=NULL,notify.of.progress=FALSE){
   
   # if no opal login details are provided look for 'opal' objects in the environment
   if(is.null(datasources)){
@@ -131,7 +133,8 @@ testclass.var<-x[j]
 calltext1<-paste0('class(', testclass.var, ')')
 next.class <- opal::datashield.aggregate(datasources, as.symbol(calltext1))
 class.vector<-c(class.vector,next.class[[1]])
-cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n\n")
+if (notify.of.progress)
+    cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n")
 }
 
 for(j in 1:length(x))
@@ -141,17 +144,20 @@ test.df<-x[j]
 if(class.vector[j]!="data.frame" && class.vector[j]!="matrix")
 	{
 	colname.vector<-c(colname.vector,test.df)
-	cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n\n")
+        if (notify.of.progress)
+            cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
 	}
 else
 	{
 	calltext2<-paste0('colnames(', test.df, ')')
     df.names <- opal::datashield.aggregate(datasources, as.symbol(calltext2))
 	 colname.vector<-c(colname.vector,df.names[[1]])
-	 cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n\n")
-	}
+         if (notify.of.progress)
+              cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
+        }
 }
-cat("\n\nBoth steps completed\n")
+if (notify.of.progress)
+    cat("\nBoth steps completed\n")
 
 #CHECK FOR DUPLICATE NAMES IN COLUMN NAME VECTOR AND ADD ".k" TO THE kth REPLICATE
 num.duplicates<-rep(0,length(colname.vector))

--- a/man/ds.cbind.o.Rd
+++ b/man/ds.cbind.o.Rd
@@ -5,7 +5,8 @@
 \title{ds.cbind.o calling cbindDS.o}
 \usage{
 ds.cbind.o(x = NULL, DataSHIELD.checks = FALSE,
-  force.colnames = NULL, newobj = "cbind.out", datasources = NULL)
+  force.colnames = NULL, newobj = "cbind.out", datasources = NULL,
+  notify.of.progress = FALSE)
 }
 \arguments{
 \item{x}{This is a vector of character strings representing the names of the elemental
@@ -60,6 +61,9 @@ apply the function solely to e.g. the second opal server in a set of three,
 the argument can be specified as: e.g. datasources=opals.em[2].
 If you wish to specify the first and third opal servers in a set you specify:
 e.g. datasources=opals.em[c(1,3)]}
+
+\item{notify.of.progress}{specifies if console output should be produce to indicate
+progress. The default value for notify.of.progress is FALSE.}
 }
 \value{
 the object specified by the <newobj> argument (or default name <cbind.out>).

--- a/man/ds.dataFrame.o.Rd
+++ b/man/ds.dataFrame.o.Rd
@@ -6,7 +6,8 @@
 \usage{
 ds.dataFrame.o(x = NULL, row.names = NULL, check.rows = FALSE,
   check.names = TRUE, stringsAsFactors = TRUE, completeCases = FALSE,
-  DataSHIELD.checks = FALSE, newobj = "df_new", datasources = NULL)
+  DataSHIELD.checks = FALSE, newobj = "df_new", datasources = NULL,
+  notify.of.progress = FALSE)
 }
 \arguments{
 \item{x}{This is a vector of character strings representing the names of the elemental
@@ -61,6 +62,9 @@ apply the function solely to e.g. the second opal server in a set of three,
 the argument can be specified as: e.g. datasources=opals.em[2].
 If you wish to specify the first and third opal servers in a set you specify:
 e.g. datasources=opals.em[c(1,3)]}
+
+\item{notify.of.progress}{specifies if console output should be produce to indicate
+progress. The default value for notify.of.progress is FALSE.}
 }
 \value{
 the object specified by the <newobj> argument (or default name <df_new>).

--- a/man/ds.rbind.o.Rd
+++ b/man/ds.rbind.o.Rd
@@ -5,7 +5,8 @@
 \title{ds.rbind.o calling rbindDS.o}
 \usage{
 ds.rbind.o(x = NULL, DataSHIELD.checks = FALSE,
-  force.colnames = NULL, newobj = "rbind.out", datasources = NULL)
+  force.colnames = NULL, newobj = "rbind.out", datasources = NULL,
+  notify.of.progress = FALSE)
 }
 \arguments{
 \item{x}{This is a vector of character strings representing the names of the elemental
@@ -60,6 +61,9 @@ apply the function solely to e.g. the second opal server in a set of three,
 the argument can be specified as: e.g. datasources=opals.em[2].
 If you wish to specify the first and third opal servers in a set you specify:
 e.g. datasources=opals.em[c(1,3)]}
+
+\item{notify.of.progress}{specifies if console output should be produce to indicate
+progress. The default value for notify.of.progress is FALSE.}
 }
 \value{
 the object specified by the <newobj> argument (or default name <rbind.out>).


### PR DESCRIPTION
Enable/disable console logging of progress via 'notify.of.progress' argument on functions 'ds.cbind.o', 'ds.rbind.o and 'ds.dataFrame.o'.