### PR TITLE
Minor tidyup: Removed 'print' from 'test-smk-ds.table2D.o.R'

### DIFF
--- a/tests/testthat/atest-smk-ds.listClientsideFunctions.o.R
+++ b/tests/testthat/atest-smk-ds.listClientsideFunctions.o.R
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2014 OBiBa,
+#               2019 University of Newcastle upon Tyne. All rights reserved.
+#
+# This program and the accompanying materials
+# are made available under the terms of the GNU Public License v3.0.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+#
+# Set up
+#
+
+# context("dsBetaTestClient::ds.listClientsideFunctions.o:smoke")
+
+source("connection_to_datasets/init_all_datasets.R")
+source("connection_to_datasets/init_smk_datasets.R")
+
+connect.smk.dataset.sim(list("LAB_TSC", "LAB_HDL"))
+
+#
+# Tests
+#
+
+context("ds.listClientsideFunctions.o()::smoke::check results")
+test_that("check results", {
+
+    res <- ds.listClientsideFunctions.o()
+
+    print("======")
+    print(res)
+    print("======")
+
+    expect_equal(res, "test", fixed=TRUE)
+})
+
+#
+# Done
+#
+
+# context("dsBetaTestClient::ds.listClientsideFunctions.o:smoke done")

--- a/tests/testthat/test-smk-ds.table2D.o.R
+++ b/tests/testthat/test-smk-ds.table2D.o.R
@@ -28,10 +28,6 @@ context("ds.table2D.o()::smoke")
 test_that("simple table2D", {
     table2D.res <- ds.table2D.o(x='D$DIS_DIAB', y='D$GENDER')
 
-    print("====")
-    print(table2D.res)
-    print("====")
-
     expect_length(table2D.res, 9)
     expect_length(table2D.res$colPercent, 3)
     expect_length(table2D.res$colPercent$`sim1-D`, 3)


### PR DESCRIPTION
Plus template for initial 'ds.listClientsideFunctions.o' smoke test.